### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "tailwind-merge": "^3.0.2",
     "tailwindcss": "^3.4.17",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "sanitize-html": "^2.15.0"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.15",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
+import sanitizeHtml from 'sanitize-html';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -14,7 +15,7 @@ export function formatDate(date: Date) {
 }
 
 export function readingTime(html: string) {
-  const textOnly = html.replace(/<[^>]+>/g, '')
+  const textOnly = sanitizeHtml(html, { allowedTags: [], allowedAttributes: {} });
   const wordCount = textOnly.split(/\s+/).length
   const readingTimeMinutes = (wordCount / 200 + 1).toFixed()
   return `${readingTimeMinutes} min read`


### PR DESCRIPTION
Potential fix for [https://github.com/atom-tr/atomtr.is-a.dev/security/code-scanning/1](https://github.com/atom-tr/atomtr.is-a.dev/security/code-scanning/1)

To fix the problem, we should use a well-tested sanitization library to ensure that all HTML tags, including potentially unsafe ones, are effectively removed. The `sanitize-html` library is a popular choice for this purpose. We will replace the current regular expression-based approach with a call to `sanitize-html` to sanitize the input string.

1. Install the `sanitize-html` library.
2. Import the `sanitize-html` library in the file.
3. Replace the current regular expression-based sanitization with a call to `sanitize-html`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
